### PR TITLE
prevent errors on bad requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ Installation
 
  * Install [`pandoc`](http://johnmacfarlane.net/pandoc/) on your system
  * Make sure `python` is installed
- * Copy the `pandoc.conf` file to the `conf.d` folder of your `apache` server
+ * Copy the `pandoc.conf` file to the `conf.available` folder of your `apache` server
+ * Enable via `a2enconf pandoc.conf`  (if apache 2.2 just copy to `conf.d` instead)
  * Create a `/usr/share/apache-pandoc` folder
  * Copy the `pandoc.py` file to the `/usr/share/apache-pandoc` folder
  * Restart your `apache` server

--- a/usr/share/apache-pandoc/pandoc.py
+++ b/usr/share/apache-pandoc/pandoc.py
@@ -166,13 +166,7 @@ if config.has_section('Pandoc'):
 	if config.has_option('Pandoc', 'webtex') and config.get('Pandoc', 'webtex') != '':
 		options += ' --webtex="' + config.get('Pandoc', 'webtex') + '"'
 
-if query == '':
-	# output html5
-	print "Content-type: text/html"
-	print
-	sys.stdout.flush()
-	os.system('pandoc ' + options + ' -s -t html5 "' + path + '"')
-elif query == 'html':
+if query == 'html':
 	# output html
 	print "Content-type: text/html"
 	print
@@ -212,6 +206,12 @@ elif query == 'raw':
 	f = open(path, 'r')
 	print f.read()
 	f.close()
+else:
+	# output html5
+	print "Content-type: text/html"
+	print
+	sys.stdout.flush()
+	os.system('pandoc ' + options + ' -s -t html5 "' + path + '"')
 
 exit(0)
 

--- a/usr/share/apache-pandoc/pandoc.py
+++ b/usr/share/apache-pandoc/pandoc.py
@@ -185,6 +185,19 @@ elif query == 'pdf':
 	print f.read()
 	f.close()
 	os.remove(pdfFile)
+elif query == 'rtf':
+	# output richtext
+	print 'Content-type: application/rtf'
+	print 'Content-disposition: attachment; filename="' + baseName + '.rtf"'
+	print
+	sys.stdout.flush()
+	fd, rtfFile = tempfile.mkstemp('.rtf')
+	os.close(fd)
+	os.system('pandoc ' + options + '-s -o "' + rtfFile + '" "' + path + '"$
+	f = open(rtfFile, 'r')
+	print f.read()
+	f.close()
+	os.remove(rtfFile)
 elif query == 'odt':
 	# output odt
 	print "Content-type: application/vnd.oasis.opendocument.text"

--- a/usr/share/apache-pandoc/pandoc.py
+++ b/usr/share/apache-pandoc/pandoc.py
@@ -193,7 +193,7 @@ elif query == 'rtf':
 	sys.stdout.flush()
 	fd, rtfFile = tempfile.mkstemp('.rtf')
 	os.close(fd)
-	os.system('pandoc ' + options + '-s -o "' + rtfFile + '" "' + path + '"$
+	os.system('pandoc ' + options + '-s -o "' + rtfFile + '" "' + path + '"')
 	f = open(rtfFile, 'r')
 	print f.read()
 	f.close()


### PR DESCRIPTION
These are minor changes I made for my usage.  Current Apache requires slightly different setup (at least on my Ubuntu based server), on bad requests I'd rather user see page as HTML than server error so reordered with else clause for all not otherwise handled formats, and the third patch supporting rtf was just for me.  Thank you for original version, great for my web sites! 
